### PR TITLE
Check that node is on workspace

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -574,7 +574,8 @@ export class Navigation {
       return;
     }
 
-    if (cursor.getCurNode() && keepPosition) {
+    const curNode = cursor.getCurNode();
+    if (curNode && curNode.getWsCoordinate() && keepPosition) {
       // Retain the cursor's previous position since it's set.
       return;
     }


### PR DESCRIPTION
This fixes the Blocks - JavaScript - Blocks transition. If the node isn't on the workspace, don't leave the cursor there.

Unsure whether this is the right fix to upstream.
