### PR TITLE
Stack navigation keys

### DIFF
--- a/src/actions/stack_navigation.ts
+++ b/src/actions/stack_navigation.ts
@@ -32,15 +32,9 @@ export class StackNavigationAction {
       callback: (workspace) => {
         const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
         if (!currentRoot) return false;
-        const rootList = workspace.getTopBlocks();
-        
-        const index = rootList.indexOf(currentRoot);
-        let newIndex;
-        do {
-          newIndex = (index - 1 + rootList.length) % rootList.length;
-        } while (!rootList[newIndex].canBeFocused());
-
-        getFocusManager().focusNode(rootList[newIndex]);
+        const prevRoot = workspace.getNavigator().getPreviousSibling(currentRoot);
+        if (!prevRoot) return false;
+        getFocusManager().focusNode(prevRoot);
         return true;
       },
       keyCodes: [SHORTCUT_PREV_STACK],
@@ -52,15 +46,9 @@ export class StackNavigationAction {
       callback: (workspace) => {
         const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
         if (!currentRoot) return false;
-        const rootList = workspace.getTopBlocks();
-        
-        const index = rootList.indexOf(currentRoot);
-        let newIndex;
-        do {
-          newIndex = (index + 1) % rootList.length;
-        } while (!rootList[newIndex].canBeFocused());
-
-        getFocusManager().focusNode(rootList[newIndex]);
+        const nextRoot = workspace.getNavigator().getNextSibling(currentRoot);
+        if (!nextRoot) return false;
+        getFocusManager().focusNode(nextRoot);
         return true;
       },
       keyCodes: [SHORTCUT_NEXT_STACK],

--- a/src/actions/stack_navigation.ts
+++ b/src/actions/stack_navigation.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ShortcutRegistry,
+  WorkspaceSvg,
+  getFocusManager,
+  utils,
+} from 'blockly/core';
+import { KeyboardShortcut } from 'node_modules/blockly/core/shortcut_registry';
+
+const SHORTCUT_PREV_STACK = utils.KeyCodes.P;
+const SHORTCUT_NEXT_STACK = utils.KeyCodes.N;
+
+/**
+ * Class for registering a shortcut for quick movement between root blocks.
+ */
+export class StackNavigationAction {
+  stackShortcuts: KeyboardShortcut[] = [];
+  install() {
+    const preconditionFn = (workspace: WorkspaceSvg) => {
+      const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+      return !!currentRoot;
+    }
+    
+    const previousStackShortcut: KeyboardShortcut = {
+      name: 'go_to_previous_stack',
+      preconditionFn,
+      callback: (workspace) => {
+        const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+        if (!currentRoot) return false;
+        const rootList = workspace.getTopBlocks();
+        
+        const index = rootList.indexOf(currentRoot);
+        let newIndex;
+        do {
+          newIndex = (index - 1 + rootList.length) % rootList.length;
+        } while (!rootList[newIndex].canBeFocused());
+
+        getFocusManager().focusNode(rootList[newIndex]);
+        return true;
+      },
+      keyCodes: [SHORTCUT_PREV_STACK],
+    };
+
+    const nextStackShortcut: KeyboardShortcut = {
+      name: 'go_to_next_stack',
+      preconditionFn,
+      callback: (workspace) => {
+        const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+        if (!currentRoot) return false;
+        const rootList = workspace.getTopBlocks();
+        
+        const index = rootList.indexOf(currentRoot);
+        let newIndex;
+        do {
+          newIndex = (index + 1) % rootList.length;
+        } while (!rootList[newIndex].canBeFocused());
+
+        getFocusManager().focusNode(rootList[newIndex]);
+        return true;
+      },
+      keyCodes: [SHORTCUT_NEXT_STACK],
+    };
+
+    ShortcutRegistry.registry.register(previousStackShortcut);
+    this.stackShortcuts.push(previousStackShortcut);
+    ShortcutRegistry.registry.register(nextStackShortcut);
+    this.stackShortcuts.push(nextStackShortcut);
+  }
+
+  /**
+   * Reverts the patched undo/redo shortcuts in the registry.
+   */
+  uninstall() {
+    this.stackShortcuts.forEach(ss => ShortcutRegistry.registry.unregister(ss.name));
+    this.stackShortcuts = [];
+  }
+}

--- a/src/actions/stack_navigation.ts
+++ b/src/actions/stack_navigation.ts
@@ -10,7 +10,7 @@ import {
   getFocusManager,
   utils,
 } from 'blockly/core';
-import { KeyboardShortcut } from 'node_modules/blockly/core/shortcut_registry';
+import {KeyboardShortcut} from 'node_modules/blockly/core/shortcut_registry';
 
 const SHORTCUT_PREV_STACK = utils.KeyCodes.P;
 const SHORTCUT_NEXT_STACK = utils.KeyCodes.N;
@@ -22,17 +22,25 @@ export class StackNavigationAction {
   stackShortcuts: KeyboardShortcut[] = [];
   install() {
     const preconditionFn = (workspace: WorkspaceSvg) => {
-      const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+      const currentRoot = workspace
+        ?.getCursor()
+        ?.getSourceBlock()
+        ?.getRootBlock();
       return !!currentRoot;
-    }
-    
+    };
+
     const previousStackShortcut: KeyboardShortcut = {
       name: 'go_to_previous_stack',
       preconditionFn,
       callback: (workspace) => {
-        const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+        const currentRoot = workspace
+          ?.getCursor()
+          ?.getSourceBlock()
+          ?.getRootBlock();
         if (!currentRoot) return false;
-        const prevRoot = workspace.getNavigator().getPreviousSibling(currentRoot);
+        const prevRoot = workspace
+          .getNavigator()
+          .getPreviousSibling(currentRoot);
         if (!prevRoot) return false;
         getFocusManager().focusNode(prevRoot);
         return true;
@@ -44,7 +52,10 @@ export class StackNavigationAction {
       name: 'go_to_next_stack',
       preconditionFn,
       callback: (workspace) => {
-        const currentRoot = workspace?.getCursor()?.getSourceBlock()?.getRootBlock();
+        const currentRoot = workspace
+          ?.getCursor()
+          ?.getSourceBlock()
+          ?.getRootBlock();
         if (!currentRoot) return false;
         const nextRoot = workspace.getNavigator().getNextSibling(currentRoot);
         if (!nextRoot) return false;
@@ -64,7 +75,9 @@ export class StackNavigationAction {
    * Reverts the patched undo/redo shortcuts in the registry.
    */
   uninstall() {
-    this.stackShortcuts.forEach(ss => ShortcutRegistry.registry.unregister(ss.name));
+    this.stackShortcuts.forEach((ss) =>
+      ShortcutRegistry.registry.unregister(ss.name),
+    );
     this.stackShortcuts = [];
   }
 }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -36,6 +36,7 @@ import {ActionMenu} from './actions/action_menu';
 import {MoveActions} from './actions/move';
 import {Mover} from './actions/mover';
 import {UndoRedoAction} from './actions/undo_redo';
+import { StackNavigationAction } from './actions/stack_navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -74,6 +75,8 @@ export class NavigationController {
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 
   moveActions = new MoveActions(this.mover);
+
+  stackNavigationAction: StackNavigationAction = new StackNavigationAction();
 
   /**
    * Original Toolbox.prototype.onShortcut method, saved by
@@ -250,6 +253,7 @@ export class NavigationController {
     this.clipboard.install();
     this.moveActions.install();
     this.shortcutDialog.install();
+    this.stackNavigationAction.install();
 
     // Initialize the shortcut modal with available shortcuts.  Needs
     // to be done separately rather at construction, as many shortcuts
@@ -273,6 +277,7 @@ export class NavigationController {
     this.undoRedoAction.uninstall();
     this.actionMenu.uninstall();
     this.shortcutDialog.uninstall();
+    this.stackNavigationAction.uninstall();
 
     for (const shortcut of Object.values(this.shortcuts)) {
       ShortcutRegistry.registry.unregister(shortcut.name);

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -36,7 +36,7 @@ import {ActionMenu} from './actions/action_menu';
 import {MoveActions} from './actions/move';
 import {Mover} from './actions/mover';
 import {UndoRedoAction} from './actions/undo_redo';
-import { StackNavigationAction } from './actions/stack_navigation';
+import {StackNavigationAction} from './actions/stack_navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 


### PR DESCRIPTION
Proposal for a previous-next button for navigating between stack roots in a workspace.

Current implementation uses `p` and `n` keys, but this is just a suggestion.

https://github.com/user-attachments/assets/fbe41352-35cc-4db0-b4a9-c4a70ee79e14

Example video shows the user in a nested block, then jumping directly to the next stack. Then going into a nested block and jumping directly back. Then cycling through blocks.